### PR TITLE
correction of the dependent

### DIFF
--- a/_fr-dep/nsubjpass.md
+++ b/_fr-dep/nsubjpass.md
@@ -9,5 +9,5 @@ subject of a passive clause.
 
 ~~~ sdparse
 La course a été gagnée par le plus jeune participant . \n The race got won by the youngest participant .
-nsubjpass(gagnée, participant)
+nsubjpass(gagnée, course)
 ~~~


### PR DESCRIPTION
The dependent of the nsubjpass relation in the French example should be "course" and not "participant" (which should be related to "gagnée" by a nmod relation)?
So correction of nsubjpass(gagnée, participant) by nsubjpass(gagnée, course)?